### PR TITLE
アプリを登録するときにトークンが必要であった問題を修正

### DIFF
--- a/packages/backend/src/server/api/call.ts
+++ b/packages/backend/src/server/api/call.ts
@@ -60,7 +60,7 @@ export default async (endpoint: string, user: CacheableLocalUser | null | undefi
 	}
 
 	//if (ep.meta.requireCredential && user == null) {
-	if ((ep.name !== 'signin' && ep.name !== 'meta') && user == null) {
+	if (!(/^(miauth\/|app\/|auth\/|signin|meta)/.test(ep.name)) && user == null) {
 		throw new ApiError({
 			message: 'Credential required.',
 			code: 'CREDENTIAL_REQUIRED',


### PR DESCRIPTION
# What
アクセストークンを発行するために必要なAPIへのアクセスにアクセストークンを要求しないように変更

# Why
アクセストークンを発行するためにアクセストークンが必要なので、アクセストークンを発行する必要があり、そのためにはアクセストークンが必要。